### PR TITLE
#163046818 Ft user able get specific meetup 

### DIFF
--- a/app/api/v1/models/meetupmodel.py
+++ b/app/api/v1/models/meetupmodel.py
@@ -30,6 +30,7 @@ class Meetups(object):
 
     @classmethod
     def find(self, id):
+        '''Find a particular question, expects id'''
         if iter(meetups):
             for meetup in meetups:
                 if meetup['id'] == id:

--- a/app/api/v1/models/meetupmodel.py
+++ b/app/api/v1/models/meetupmodel.py
@@ -27,3 +27,11 @@ class Meetups(object):
         }
         meetups.append(meetup)
         return meetup
+
+    @classmethod
+    def find(self, id):
+        if iter(meetups):
+            for meetup in meetups:
+                if meetup['id'] == id:
+                    return meetup
+            return None

--- a/app/api/v1/views/meetupview.py
+++ b/app/api/v1/views/meetupview.py
@@ -36,3 +36,18 @@ def get():
     response = jsonify(upcomingmeetups)
     response.status_code = 200
     return response
+
+
+@meetupreq.route('/meetups/<int:id>', methods=['GET'])
+def get_by_id(id):
+    '''Get a specific meetup with a particular ID'''
+    meetup_obj = Meetups.find(id)
+    if meetup_obj:
+        meetup = {
+            'status': 200,
+            'data': [meetup_obj]
+        }
+        response = jsonify(meetup)
+        response.status_code = 200
+        return response
+    return make_response(jsonify({"message": "Not Found"}), 404)

--- a/app/test/v1/test_meetups.py
+++ b/app/test/v1/test_meetups.py
@@ -47,7 +47,17 @@ class MeetupsTestCase(unittest.TestCase):
     def test_get_upcoming(self):
         response = self.client.get('/api/v1/meetups/upcoming')
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Nairobi Go Meetup', str(response.data))
+        self.assertIn('Nairobi Go Meetup', str(json.loads(response.data)))
+
+    def test_get_meetup(self):
+        response = self.client.get('/api/v1/meetups/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Nairobi Go Meetup', str(json.loads(response.data)))
+
+    def test_get_meetup_notfound(self):
+        response = self.client.get('/api/v1/meetups/1')
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('Not Found', str(json.loads(response.data)))
 
     def tearDown(self):
         meetups.pop()

--- a/app/test/v1/test_meetups.py
+++ b/app/test/v1/test_meetups.py
@@ -55,7 +55,7 @@ class MeetupsTestCase(unittest.TestCase):
         self.assertIn('Nairobi Go Meetup', str(json.loads(response.data)))
 
     def test_get_meetup_notfound(self):
-        response = self.client.get('/api/v1/meetups/1')
+        response = self.client.get('/api/v1/meetups/0')
         self.assertEqual(response.status_code, 404)
         self.assertIn('Not Found', str(json.loads(response.data)))
 


### PR DESCRIPTION
## What does this PR do?
This creates a `/meetups/<int:id>` endpoint. This allows a user to get a particular meetup

### Description of the Task to be completed
This will allow a user to get  a particular meetup by just providing the meetup id to the endpoint `/meetups/<id>` the expected request is GET request and the response is `200 ` for OK and `404` for NOT FOUND

### Any background Tasks?
Tests for this feature

### Testing
1. `git clone https://github.com/j0nimost/Questioner.git`
2. `cd Questioner/`
3. `virtualenv env`
4. `source env/bin/activate`
5. `pip install -r requirements.txt`
6. `pytest`

### Screenshot
![screenshot from 2019-01-11 00-21-31](https://user-images.githubusercontent.com/24381727/50998487-9396db80-1538-11e9-9c43-ab8d7ba9d2b3.png)
