### PR TITLE
#163047020 Ft user able downvote 

### DIFF
--- a/app/api/v1/models/questionmodel.py
+++ b/app/api/v1/models/questionmodel.py
@@ -18,7 +18,25 @@ class Questions(Meetups):
             'userid': userid,
             'meetupid': meetupid,
             'title': title,
-            'body': body
+            'body': body,
+            'votes': 0
         }
         questions.append(question)
+        return question
+
+    @classmethod
+    def find(self, id):
+        '''Finds a specific question and returns a tuple'''
+        if iter(questions):
+            for index, question in enumerate(questions):
+                if question['id'] == id:
+                    return index, question
+        return None, None
+
+    @classmethod
+    def update(self, question_update):
+        '''Updates a question by providing votes, expects a question object'''
+        index, question = self.find(question_update['id'])
+        question['votes'] += question_update['votes']
+        questions[index] = question
         return question

--- a/app/api/v1/models/questionmodel.py
+++ b/app/api/v1/models/questionmodel.py
@@ -34,9 +34,9 @@ class Questions(Meetups):
         return None, None
 
     @classmethod
-    def update(self, question_update):
+    def update(self, id: int, votes: int):
         '''Updates a question by providing votes, expects a question object'''
-        index, question = self.find(question_update['id'])
-        question['votes'] += question_update['votes']
+        index, question = self.find(id)
+        question['votes'] += votes
         questions[index] = question
         return question

--- a/app/api/v1/views/questionview.py
+++ b/app/api/v1/views/questionview.py
@@ -38,7 +38,7 @@ def downvote(id):
             question = Questions.update(id, votes)
             question_obj = {
                 'status': 202,
-                'data': question
+                'data': [question]
             }
             response = jsonify(question_obj)
             response.status_code = 202

--- a/app/api/v1/views/questionview.py
+++ b/app/api/v1/views/questionview.py
@@ -26,3 +26,24 @@ def post():
 
     else:
         return make_response(jsonify({"message": "invalid request type"}), 400)
+
+
+@ques.route('/questions/<int:id>/downvote', methods=['PATCH'])
+def downvote(id):
+    '''Downvotes a Question'''
+    if request.json:
+        votes = request.json['votes']
+        _, find_question = Questions.find(id)
+        if find_question:
+            question = Questions.update(id, votes)
+            question_obj = {
+                'status': 202,
+                'data': question
+            }
+            response = jsonify(question_obj)
+            response.status_code = 202
+            return response
+        else:
+            return make_response(jsonify({'message': 'Not Found'}), 404)
+    else:
+        return make_response(jsonify({'message': 'invalid request type'}))

--- a/app/test/v1/test_questions.py
+++ b/app/test/v1/test_questions.py
@@ -42,14 +42,28 @@ class MeetupsTestCase(unittest.TestCase):
         self.assertIn('invalid request type', str(json.loads(response.data)))
 
     def test_downvote(self):
-        question_downvote = questions[0]
-        question_downvote['votes'] = -1
+        question_downvote = {
+            'votes': -1
+        }
         response = self.client.patch('api/v1/questions/1/downvote',
                                      data=json.dumps(question_downvote),
                                      content_type='application/json')
         self.assertEqual(response.status_code, 202)
         data = json.loads(response.data)
+        print(data)
         self.assertEqual(14, data['data']['votes'])
+
+    def test_downvote_notfound(self):
+        question_downvote = {
+            'votes': -1
+        }
+        response = self.client.patch('api/v1/questions/0/downvote',
+                                     data=json.dumps(question_downvote),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.data)
+        print(data)
+        self.assertEqual('Not Found', data['message'])
 
     def tearDown(self):
         questions.pop()

--- a/app/test/v1/test_questions.py
+++ b/app/test/v1/test_questions.py
@@ -23,7 +23,8 @@ class MeetupsTestCase(unittest.TestCase):
             'userid': 1,
             'meetupid': 2,
             'title': 'Will there be food',
-            'body': 'I will only attend if there is food'
+            'body': 'I will only attend if there is food',
+            'votes': 15
         })
 
     def test_create_question(self):
@@ -39,6 +40,16 @@ class MeetupsTestCase(unittest.TestCase):
                                     content_type='application/xml')
         self.assertEqual(response.status_code, 400)
         self.assertIn('invalid request type', str(json.loads(response.data)))
+
+    def test_downvote(self):
+        question_downvote = questions[0]
+        question_downvote['votes'] = -1
+        response = self.client.patch('api/v1/questions/1/downvote',
+                                     data=json.dumps(question_downvote),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 202)
+        data = json.loads(response.data)
+        self.assertEqual(14, data['data']['votes'])
 
     def tearDown(self):
         questions.pop()

--- a/app/test/v1/test_questions.py
+++ b/app/test/v1/test_questions.py
@@ -51,7 +51,7 @@ class MeetupsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 202)
         data = json.loads(response.data)
         print(data)
-        self.assertEqual(14, data['data']['votes'])
+        self.assertEqual(14, data['data'][0]['votes'])
 
     def test_downvote_notfound(self):
         question_downvote = {


### PR DESCRIPTION
## What does this PR do?
This allows a user to `downvote` a question provided on the API.

### Description of the Task to be completed
This will allow a user to downvote a question through the `api/v1/questions/<id>/downvote` endpoint using the PATCH request. The user will be expected to provide;
- `votes` type int(negative value)

### Any background Tasks?
Testing this feature

### Testing
1. `git clone https://github.com/j0nimost/Questioner.git`
2. `cd Questioner/`
3. `virtualenv env`
4. `source env/bin/activate`
5. `pip install -r requirements.txt`
6. `pytest test_question.py`

### Screenshots
![screenshot from 2019-01-11 09-55-07](https://user-images.githubusercontent.com/24381727/51018440-a46f3d80-1588-11e9-85a5-edfdfb07f660.png)
