### PR TITLE
#163190357 Ft admin able update meetup 

### DIFF
--- a/app/api/v1/views/meetupview.py
+++ b/app/api/v1/views/meetupview.py
@@ -58,6 +58,21 @@ def get_by_id(id):
     return make_response(jsonify({"message": "Not Found"}), 404)
 
 
+@meetupreq.route('/meetups/<int:id>', methods=['PATCH'])
+@validate_input('meetup')
+def update(id):
+    '''Update a meetup'''
+    update_meetup = request.json
+    _, meetup_ = meetup_obj.find(id)
+    if meetup_:
+        data = meetup_obj.update(update_meetup)
+        response = jsonify(data)
+        response.status_code = 202
+        return response
+    else:
+        return make_response(jsonify({'message': 'Not Found'}), 404)
+
+
 @meetupreq.route('/meetups/<int:id>/rsvps', methods=['POST'])
 @validate_input('rsvp')
 def post_rsvp(id):

--- a/app/test/v1/test_meetups.py
+++ b/app/test/v1/test_meetups.py
@@ -92,6 +92,41 @@ class MeetupsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn('Not Found', str(json.loads(response.data)))
 
+    def test_update_meetup(self):
+        '''Test update meetup'''
+        update = meetups[0]
+        update['topic'] = 'Golang Devs'
+        response = self.client.patch('/api/v1/meetups/1',
+                                     data=json.dumps(update),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 202)
+        data = json.loads(response.data)
+        self.assertEqual('Golang Devs', data['topic'])
+
+    def test_update_meetup_validation(self):
+        '''Test meetup object types match schema'''
+        update = meetups[0]
+        update['topic'] = 5
+        response = self.client.patch('/api/v1/meetups/1',
+                                     data=json.dumps(update),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected 5 is not of type 'string'",
+                         data['message'])
+
+    def test_update_meetup_missing_object(self):
+        '''Test meetup json missing object'''
+        update = meetups[0]
+        del update['topic']
+        response = self.client.patch('/api/v1/meetups/1',
+                                     data=json.dumps(update),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected 'topic' is a required property",
+                         data['message'])
+
     def test_create_rsvp(self):
         '''Test create rsvp'''
         pass


### PR DESCRIPTION
## What does this PR do?
This allows an admin to update a meetup

### Description of the Task to be completed
This will allow an Admin to update a meetup using the `PATCH` request on the `/api/v1/meetups/<id>` endpoint. 

### Any background Tasks?
Tests for this feature

### Testing
1. `git clone https://github.com/j0nimost/Questioner.git`
2. `cd Questioner/`
3. `virtualenv env`
4. `source env/bin/activate`
5. `pip install -r requirements.txt`
6. `pytest`

### Screenshots
![screenshot from 2019-01-15 07-31-31](https://user-images.githubusercontent.com/24381727/51158932-c1ad5000-1897-11e9-9fe8-063b1e1ba778.png)

