### PR TITLE
#163190434 Ft admin able delete meetup 

### DIFF
--- a/app/api/v1/views/meetupview.py
+++ b/app/api/v1/views/meetupview.py
@@ -73,6 +73,19 @@ def update(id):
         return make_response(jsonify({'message': 'Not Found'}), 404)
 
 
+@meetupreq.route('/meetups/<int:id>', methods=['DELETE'])
+def delete(id):
+    '''Delete a meetup'''
+    _, meetup = meetup_obj.find(id)
+    if meetup:
+        meetup_obj.delete(id)
+        response = jsonify({"message": "Successfully Deleted"})
+        response.status_code = 200
+        return response
+    else:
+        return make_response(jsonify({"message": "Not Found"}), 404)
+
+
 @meetupreq.route('/meetups/<int:id>/rsvps', methods=['POST'])
 @validate_input('rsvp')
 def post_rsvp(id):

--- a/app/test/v1/test_meetups.py
+++ b/app/test/v1/test_meetups.py
@@ -127,6 +127,20 @@ class MeetupsTestCase(unittest.TestCase):
         self.assertEqual("unexpected 'topic' is a required property",
                          data['message'])
 
+    def test_delete_meetup(self):
+        '''Test delete meetup functionality'''
+        response = self.client.delete('/api/v1/meetups/1')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual('Successfully Deleted', data['message'])
+
+    def test_delete_meetup_notfound(self):
+        '''Test delete meetup, meetup not found '''
+        response = self.client.delete('/api/v1/meetups/0')
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.data)
+        self.assertEqual('Not Found', data['message'])
+
     def test_create_rsvp(self):
         '''Test create rsvp'''
         pass


### PR DESCRIPTION
## What does this PR do?
This allows an Admin to delete a meetup

### Description of the Task to be completed
The admin can delete a meetup by using `DELETE` request on the `api/v1/meetups/<id>` endpoint

### Any background Tasks?
Tests for this feature

### Testing
1. `git clone https://github.com/j0nimost/Questioner.git`
2. `cd Questioner/`
3. `virtualenv env`
4. `source env/bin/activate`
5. `pip install -r requirements.txt`
6. `pytest`

### Screenshots
![screenshot from 2019-01-15 07-57-07](https://user-images.githubusercontent.com/24381727/51159721-b9efaa80-189b-11e9-8898-f102134258c4.png)
