### PR TITLE
#163185575 Ft user able create comment 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ from instance.config import app_config
 
 from .api.v1.views.meetupview import meetupreq
 from .api.v1.views.questionview import ques
+from .api.v1.views.commentview import comment
 
 
 def create_app(config):
@@ -16,4 +17,5 @@ def create_app(config):
 
     app.register_blueprint(meetupreq)
     app.register_blueprint(ques)
+    app.register_blueprint(comment)
     return app

--- a/app/api/v1/models/basemodel.py
+++ b/app/api/v1/models/basemodel.py
@@ -2,6 +2,7 @@
 meetups = []
 questions = []
 rsvps = []
+comments = []
 
 
 class BaseModel(object):
@@ -57,5 +58,6 @@ class BaseModel(object):
 dbconfig = {
     'meetupsdb': meetups,
     'questiondb': questions,
-    'rsvpsdb': rsvps
+    'rsvpsdb': rsvps,
+    'commentdb': comments
 }

--- a/app/api/v1/models/commentmodel.py
+++ b/app/api/v1/models/commentmodel.py
@@ -1,0 +1,34 @@
+import datetime
+
+from .basemodel import BaseModel, comments
+
+
+class Comments(BaseModel):
+    '''
+    The Comment Model Class defines the business logic
+    '''
+    def __init__(self):
+        '''Initialize db'''
+        super().__init__('commentdb')
+
+    def create_meetup(self, userid: int, questionid: int,
+                      body: str):
+        '''Create a comment'''
+        comment = {
+            'id': len(comments)+1,
+            'time': str(datetime.datetime.now()),
+            'userid': userid,
+            'questionid': questionid,
+            'body': body
+        }
+        self.save(comment)
+
+comment_schema = {
+    "$schema": "https://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "userid": {"type": "number"},
+        "body": {"type": "string"}
+    },
+    "required": ["userid", "body"]
+}

--- a/app/api/v1/utils/schema.py
+++ b/app/api/v1/utils/schema.py
@@ -1,10 +1,12 @@
 from ..models.meetupmodel import meetup_schema, rsvp_schema
 from ..models.questionmodel import question_schema, vote_schema
+from ..models.commentmodel import comment_schema
 
 
 config = {
     'meetup': meetup_schema,
     'rsvp': rsvp_schema,
     'question': question_schema,
-    'vote': vote_schema
+    'vote': vote_schema,
+    'comment': comment_schema
 }

--- a/app/api/v1/views/commentview.py
+++ b/app/api/v1/views/commentview.py
@@ -1,0 +1,33 @@
+from flask import request, jsonify, make_response
+from flask import Blueprint
+
+
+from ..models.commentmodel import Comments
+from ..models.questionmodel import Questions
+from ..utils.validation import validate_input
+
+comment = Blueprint('comment', __name__, url_prefix='/api/v1')
+
+comment_obj = Comments()
+ques_obj = Questions()
+
+
+@comment.route('/questions/<int:id>/comments', methods=['POST'])
+@validate_input('comment')
+def post(id):
+    '''Create a comment endpoint'''
+    _, question = ques_obj.find(id)
+    if question:
+        userid = request.json['userid']
+        body = request.json['body']
+        comment_obj.create_meetup(userid, id, body)
+        data = comment_obj.return_data()
+        data_response = {
+            'status': 201,
+            'data': data
+        }
+        response = jsonify(data_response)
+        response.status_code = 201
+        return response
+    else:
+        return make_response(jsonify({"message": "Not Found"}), 404)

--- a/app/test/v1/test_comments.py
+++ b/app/test/v1/test_comments.py
@@ -1,0 +1,89 @@
+import json
+import unittest
+
+from app import create_app
+from ...api.v1.models.basemodel import comments, questions
+
+
+class CommentTestCase(unittest.TestCase):
+    '''Tests the Comments Endpoints'''
+    def setUp(self):
+        self.app = create_app('development')
+        self.client = self.app.test_client()
+
+        self.comment = {
+            'userid': 1,
+            'body': "I don't know where the event is could" +
+                    " you please share the location"
+        }
+
+        comments.append({
+            'id': 1,
+            'time': '2019-01-15 08:43:30.571696',
+            'userid': 1,
+            'questionid': 1,
+            'body': "Will there be food?"
+        })
+
+        questions.append({
+            'id': 1,
+            'userid': 1,
+            'meetupid': 2,
+            'title': 'Will there be food',
+            'body': 'I will only attend if there is food',
+            'votes': 15
+        })
+
+    def test_create_comment(self):
+        '''Test create comment'''
+        response = self.client.post('/api/v1/questions/1/comments',
+                                    data=json.dumps(self.comment),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data)
+        self.assertIn(" you please share the location", data['data']['body'])
+
+    def test_create_comment_validation(self):
+        '''Test comment object types match schema'''
+        self.comment['userid'] = '1'
+        response = self.client.post('api/v1/questions/1/comments',
+                                    data=json.dumps(self.comment),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected '1' is not of type 'number'",
+                         data['message'])
+
+    def test_create_comment_missing_object(self):
+        '''Test comment json missing object'''
+        del self.comment['userid']
+        response = self.client.post('api/v1/questions/1/comments',
+                                    data=json.dumps(self.comment),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected 'userid' is a required property",
+                         data['message'])
+
+    def test_create_comment_badrequest(self):
+        '''Test create comment with empty json'''
+        response = self.client.post('api/v1/questions/1/comments',
+                                    data=json.dumps(self.comment),
+                                    content_type='application/xml')
+        self.assertEqual(response._status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected None is not of type 'object'",
+                         data['message'])
+
+    def test_create_comment_notfound(self):
+        '''Test Question not found'''
+        response = self.client.post('api/v1/questions/0/comments',
+                                    data=json.dumps(self.comment),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.data)
+        self.assertEqual('Not Found', data['message'])
+
+    def tearDown(self):
+        comments.pop()
+        questions.pop()


### PR DESCRIPTION
## What does this PR do?
This allows a user to create a comment under a question

### Description of the Task to be completed 
This will allow a user to `POST` a comment under a specific question. The endpoint of choice is `api/v1/questions/<id>/comments`. Expected objects are;
- `Userid` type int
- `Body` type string

### Any background Tasks?
Tests for this feature

### Testing
1. `git clone https://github.com/j0nimost/Questioner.git`
2. `cd Questioner/`
3. `virtualenv env`
4. `source env/bin/activate`
5. `pip install -r requirements.txt`
6. `pytest`

### Screenshot
![screenshot from 2019-01-15 09-29-46](https://user-images.githubusercontent.com/24381727/51163114-b400c600-18a9-11e9-9d48-4dcc06239e0e.png)
