### PR TITLE
#163189955 Ft user able view comments 

### DIFF
--- a/app/api/v1/models/commentmodel.py
+++ b/app/api/v1/models/commentmodel.py
@@ -23,6 +23,14 @@ class Comments(BaseModel):
         }
         self.save(comment)
 
+    def get_all(self, id: int):
+        '''Get all comments under a question'''
+        ques_comments = []
+        for comment in comments:
+            if comment['questionid'] == id:
+                ques_comments.append(comment)
+        return ques_comments
+
 comment_schema = {
     "$schema": "https://json-schema.org/schema#",
     "type": "object",

--- a/app/api/v1/views/commentview.py
+++ b/app/api/v1/views/commentview.py
@@ -31,3 +31,20 @@ def post(id):
         return response
     else:
         return make_response(jsonify({"message": "Not Found"}), 404)
+
+
+@comment.route('/questions/<int:id>/comments', methods=['GET'])
+def get(id):
+    '''Get all comments under a question'''
+    _, question = ques_obj.find(id)
+    if question:
+        comments = comment_obj.get_all(id)
+        data = {
+            'status': 200,
+            'data': comments
+        }
+        response = jsonify(data)
+        response.status_code = 200
+        return response
+    else:
+        return make_response(jsonify({'message': 'Not Found'}), 404)

--- a/app/test/v1/test_comments.py
+++ b/app/test/v1/test_comments.py
@@ -84,6 +84,20 @@ class CommentTestCase(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual('Not Found', data['message'])
 
+    def test_get_comments(self):
+        '''Test Get comments under a question'''
+        response = self.client.get('/api/v1/questions/1/comments')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIsInstance(data['data'], list)
+
+    def test_get_comments_notfound(self):
+        '''Test Get comments, not found question'''
+        response = self.client.get('/api/v1/questions/0/comments')
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.data)
+        self.assertEqual('Not Found', data['message'])
+
     def tearDown(self):
         comments.pop()
         questions.pop()


### PR DESCRIPTION
## What does this PR do?
This adds a get all comments endpoint.

### Description of the Task to be completed
This PR will introduce a feature that will allow a user to view all the comments under a question.
The `GET` request is used on the `/questions/<id>/comments` endpoint. 

### Any background Tasks?
Tests for this feature

### Testing
1. `git clone https://github.com/j0nimost/Questioner.git`
2. `cd Questioner/`
3. `virtualenv env`
4. `source env/bin/activate`
5. `pip install -r requirements.txt`
6. `pytest`

### Screenshot
![screenshot from 2019-01-15 14-12-59](https://user-images.githubusercontent.com/24381727/51177638-3781dd80-18d1-11e9-8686-144ec07d3e47.png)
