### PR TITLE
#163190083 Ft user able update comment 

### DIFF
--- a/app/api/v1/views/commentview.py
+++ b/app/api/v1/views/commentview.py
@@ -48,3 +48,22 @@ def get(id):
         return response
     else:
         return make_response(jsonify({'message': 'Not Found'}), 404)
+
+
+@comment.route('/comments/<int:id>', methods=['PATCH'])
+@validate_input('comment')
+def update_comment(id):
+    '''Update a comment'''
+    _, data = comment_obj.find(id)
+    if data:
+        data_upd = request.json
+        updated_obj = comment_obj.update(data_upd)
+        comment_upt = {
+            'status': 202,
+            'data': updated_obj
+        }
+        response = jsonify(comment_upt)
+        response.status_code = 202
+        return response
+    else:
+        return make_response(jsonify({"message": "Not Found"}))

--- a/app/test/v1/test_comments.py
+++ b/app/test/v1/test_comments.py
@@ -98,6 +98,53 @@ class CommentTestCase(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual('Not Found', data['message'])
 
+    def test_update_comments(self):
+        '''Test update comments'''
+        comment = comments[0]
+        comment['body'] = 'It has been rescheduled to a later date'
+        response = self.client.patch('/api/v1/comments/1',
+                                     data=json.dumps(comment),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 202)
+        data = json.loads(response.data)
+        self.assertEqual('It has been rescheduled to a later date',
+                         data['data']['body'])
+
+    def test_update_comments_validation(self):
+        '''Test update objects type match schema'''
+        comment = comments[0]
+        comment['body'] = 20
+        response = self.client.patch('/api/v1/comments/1',
+                                     data=json.dumps(comment),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected 20 is not of type 'string'",
+                         data['message'])
+
+    def test_update_comments_missing_object(self):
+        '''Test update object, missing json object'''
+        comment = comments[0]
+        del comment['body']
+        response = self.client.patch('/api/v1/comments/1',
+                                     data=json.dumps(comment),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected 'body' is a required property",
+                         data['message'])
+
+    def test_update_comments_badrequest(self):
+        '''Test comment update, comment not found'''
+        comment = comments[0]
+        response = self.client.patch('/api/v1/comments/1',
+                                     data=json.dumps(comment),
+                                     content_type='application/xml')
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual("unexpected None is not of type 'object'",
+                         data['message'])
+
     def tearDown(self):
         comments.pop()
         questions.pop()


### PR DESCRIPTION
## What does this PR do?
This creates an Update comment endpoint

### Description of the Task to be completed
This adds an update endpoint that accepts `PATCH` request on the `comments/<id>` endpoint. 

### Any background Tasks?
Tests for this feature

### Testing
1. `git clone https://github.com/j0nimost/Questioner.git`
2. `cd Questioner/`
3. `virtualenv env`
4. `source env/bin/activate`
5. `pip install -r requirements.txt`
6. `pytest`

### Screenshot
![screenshot from 2019-01-15 15-46-08](https://user-images.githubusercontent.com/24381727/51182001-d280b480-18dd-11e9-8b71-2d0dacf0ca73.png)
