### PR TITLE
#163282426 Bg fix create meetup response 

### DIFF
--- a/app/api/v1/views/commentview.py
+++ b/app/api/v1/views/commentview.py
@@ -24,7 +24,7 @@ def post(id):
         data = comment_obj.return_data()
         data_response = {
             'status': 201,
-            'data': data
+            'data': [data]
         }
         response = jsonify(data_response)
         response.status_code = 201

--- a/app/api/v1/views/commentview.py
+++ b/app/api/v1/views/commentview.py
@@ -60,7 +60,7 @@ def update_comment(id):
         updated_obj = comment_obj.update(data_upd)
         comment_upt = {
             'status': 202,
-            'data': updated_obj
+            'data': [updated_obj]
         }
         response = jsonify(comment_upt)
         response.status_code = 202

--- a/app/api/v1/views/meetupview.py
+++ b/app/api/v1/views/meetupview.py
@@ -72,7 +72,7 @@ def update(id):
         data = meetup_obj.update(update_meetup)
         meetup_upd = {
             'status': 202,
-            'data': data
+            'data': [data]
         }
         response = jsonify(meetup_upd)
         response.status_code = 202

--- a/app/api/v1/views/meetupview.py
+++ b/app/api/v1/views/meetupview.py
@@ -24,7 +24,11 @@ def post():
     meetup_obj.create_meetup(location, images, topic,
                              happeningOn, tags)
     meetup_ = meetup_obj.return_data()
-    response = jsonify(meetup_)
+    response_obj = {
+        "status": 201,
+        "data": [meetup_]
+    }
+    response = jsonify(response_obj)
     response.status_code = 201
     return response
 

--- a/app/test/v1/test_comments.py
+++ b/app/test/v1/test_comments.py
@@ -41,7 +41,8 @@ class CommentTestCase(unittest.TestCase):
                                     content_type='application/json')
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data)
-        self.assertIn(" you please share the location", data['data']['body'])
+        self.assertIn(" you please share the location",
+                      data['data'][0]['body'])
 
     def test_create_comment_validation(self):
         '''Test comment object types match schema'''

--- a/app/test/v1/test_comments.py
+++ b/app/test/v1/test_comments.py
@@ -109,7 +109,7 @@ class CommentTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 202)
         data = json.loads(response.data)
         self.assertEqual('It has been rescheduled to a later date',
-                         data['data']['body'])
+                         data['data'][0]['body'])
 
     def test_update_comments_validation(self):
         '''Test update objects type match schema'''

--- a/app/test/v1/test_meetups.py
+++ b/app/test/v1/test_meetups.py
@@ -39,8 +39,8 @@ class MeetupsTestCase(unittest.TestCase):
                                     data=json.dumps(self.meetup),
                                     content_type='application/json')
         self.assertEqual(response.status_code, 201)
-        print('{} code'.format(response.status_code))
-        self.assertIn('Nairobi Go Meetup', str(json.loads(response.data)))
+        data = json.loads(response.data)
+        self.assertIn('Nairobi Go Meetup', data['data'][0]['topic'])
 
     def test_create_meetup_badrequest(self):
         '''Test create a meetup empty json object'''

--- a/app/test/v1/test_meetups.py
+++ b/app/test/v1/test_meetups.py
@@ -101,7 +101,7 @@ class MeetupsTestCase(unittest.TestCase):
                                      content_type='application/json')
         self.assertEqual(response.status_code, 202)
         data = json.loads(response.data)
-        self.assertEqual('Golang Devs', data['data']['topic'])
+        self.assertEqual('Golang Devs', data['data'][0]['topic'])
 
     def test_update_meetup_validation(self):
         '''Test meetup object types match schema'''


### PR DESCRIPTION
## What does this PR do?
This fixes a bug in the responses of a a few endpoints

### Description of the Task to be completed
The is a specific design standard expected to be used to return responses from views. 

### Expected 
The return structure ought to be like
```
    "status": 201,
    "data": [] #array
```
### Actual
The actual return structure is really like
```
    "status": 201,
     "data": object
```

This PR fixes also a similar issue with other views;
- Comments
- Meetup

### Any background Tasks
None

### Testing 
None

### Screenshot
![screenshot from 2019-01-17 10-23-18](https://user-images.githubusercontent.com/24381727/51301991-0ecd2580-1a42-11e9-9d0d-dc84946d9fd1.png)
