### PR TITLE
#163898828 Ft user update comment 

### DIFF
--- a/app/api/v2/models/commentmodel.py
+++ b/app/api/v2/models/commentmodel.py
@@ -26,6 +26,17 @@ class CommentModel(BaseModel):
         id_ = super().insert(comment, comment_query)
         return id_
 
+    def update_comment(self, commentid: int, body: str):
+        '''Update a comment'''
+        comment = {
+            "commentid": commentid,
+            "body": body
+        }
+
+        update_query = '''UPDATE {table} SET body=%(body)s WHERE id=%(commentid)s
+                       RETURNING id;'''.format(table=self.table)
+        id_ = super().update(update_query, comment)
+        return id_
 
 comment_schema = {
     "$schema": "http://json-schema.org/schema#",

--- a/app/api/v2/views/commentview.py
+++ b/app/api/v2/views/commentview.py
@@ -35,3 +35,27 @@ def post(quesid):
         "error": "Not Found"
     }
     return jsonify(notfound), 404
+
+
+@commentv2.route('comments/<int:commentid>', methods=['PATCH'])
+@validate_input('comment')
+@isAuthorized("")
+def patch(commentid):
+    '''Update a comment'''
+    body = request.json['body']
+    exists = comment_obj.exists("id", commentid)
+    if exists:
+        # update
+        id_ = comment_obj.update_comment(commentid, body)
+        comment = comment_obj.fetch('id', id_)
+        comment_return = {
+            "status": 202,
+            "data": [comment]
+        }
+        return jsonify(comment_return), 202
+
+    error = {
+        "status": 404,
+        "error": "Not Found"
+    }
+    return jsonify(error), 404

--- a/app/test/v2/test_comment.py
+++ b/app/test/v2/test_comment.py
@@ -100,7 +100,7 @@ class CommentTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         data = json.loads(response.data)
         self.assertEqual(data['error'], "unexpected pattern for body")
-        
+
         del self.comment['body']
         response = self.client.post('api/v2/questions/1/comments',
                                     data=json.dumps(self.comment),
@@ -134,6 +134,46 @@ class CommentTestCase(unittest.TestCase):
             data['error'],
             "unexpected 'One of the most effective approach to better meetings is No Meeting without an Agenda.A few years ago, I worked for a customer where meetings were the answer for almost everything, but no one bothered writing down the questions. After a while, it got extremely annoying and our team started to decline every meeting request with no fixed agenda. From that point on, meetings got shorter and actually had an outcome. ' is too long"
             )
+
+    def test_update_comment(self):
+        '''Test the update comment'''
+        meetup_resp = self.client.post('api/v2/meetups',
+                                       data=json.dumps(self.meetup),
+                                       headers=self.auth_header)
+        self.assertEqual(meetup_resp.status_code, 201)
+        meetup_data = json.loads(meetup_resp.data)
+        meetupid = meetup_data['data'][0]['id']
+        self.assertIsInstance(meetupid, int)
+        ques_resp = self.client.post(
+            '''api/v2/meetups/{}/questions'''.format(meetupid),
+            data=json.dumps(self.question),
+            headers=self.auth_header
+            )
+        self.assertEqual(ques_resp.status_code, 201)
+        ques_data = json.loads(ques_resp.data)
+        quesid = ques_data['data'][0]['id']
+        self.assertIsInstance(quesid, int)
+
+        comment_res = self.client.post(
+            '''api/v2/questions/{}/comments'''.format(quesid),
+            data=json.dumps(self.comment),
+            headers=self.auth_header
+            )
+        self.assertEqual(comment_res.status_code, 201)
+        comment_data = json.loads(comment_res.data)
+        self.assertEqual('I think the meetup will be in Senteru plaza',
+                         comment_data['data'][0]['body'])
+
+        commentid = comment_data['data'][0]['id']
+        self.comment['body'] = 'Where is the meeting point?'
+        update_response = self.client.patch(
+                        'api/v2/comments/{}'.format(commentid),
+                        data=json.dumps(self.comment),
+                        headers=self.auth_header)
+        self.assertEqual(update_response.status_code, 202)
+        update_data = json.loads(update_response.data)
+        self.assertEqual('Where is the meeting point?',
+                         update_data['data'][0]['body'])
 
     def tearDown(self):
         with self.app.app_context():

--- a/app/test/v2/test_comment.py
+++ b/app/test/v2/test_comment.py
@@ -175,6 +175,17 @@ class CommentTestCase(unittest.TestCase):
         self.assertEqual('Where is the meeting point?',
                          update_data['data'][0]['body'])
 
+    def test_update_comment_notfound(self):
+        '''Test missing comment'''
+        update_response = self.client.patch(
+                        'api/v2/comments/0',
+                        data=json.dumps(self.comment),
+                        headers=self.auth_header)
+        self.assertEqual(update_response.status_code, 404)
+        update_data = json.loads(update_response.data)
+        self.assertEqual('Not Found',
+                         update_data['error'])
+
     def tearDown(self):
         with self.app.app_context():
             drop_tables()


### PR DESCRIPTION
## What does this PR do?
This allows a user to update a comment they made.

### Description of the Task to be completed
This will allow a user to update a comment they made using `PATCH` request on `comments/<id>` endpoint.

### Any background Tasks?
Tests for this Feature

### Testing
- `$ git clone https://github.com/j0nimost/Questioner.git`
- `$ cd Questioner/app/tests/v2/`
- `$ pytest test_comment.py`

### Screenshot
None