### PR TITLE
#163972049 Ft user view specific meetup

### DIFF
--- a/app/api/v2/models/basemodel.py
+++ b/app/api/v2/models/basemodel.py
@@ -15,6 +15,11 @@ class BaseModel(object):
         '''Initialize Db connection'''
         self.table = table
 
+    def db_instance(self):
+        '''return db instance'''
+        dbconn = get_db(current_app.env)
+        return dbconn
+
     def insert(self, data: dict, query: str):
         '''abstract method to insert data'''
         dbconn = get_db(current_app.env)

--- a/app/api/v2/models/meetupmodel.py
+++ b/app/api/v2/models/meetupmodel.py
@@ -14,15 +14,15 @@ class MeetupModel(BaseModel):
         meetup_dict = {
             'createdOn': createdOn,
             'topic': topic,
-            'location': location,
+            'venue': location,
             'happeningOn': happeningOn
         }
 
         query = '''
                 INSERT INTO {}(userid,createdOn, topic
-                , location, happeningOn)
+                , venue, happeningOn)
                 VALUES({}, %(createdOn)s, %(topic)s
-                , %(location)s, %(happeningOn)s)
+                , %(venue)s, %(happeningOn)s)
                 RETURNING id;'''.format(self.table, userid)
         id_ = super().insert(meetup_dict, query)
         return id_

--- a/app/api/v2/views/meetupview.py
+++ b/app/api/v2/views/meetupview.py
@@ -22,6 +22,28 @@ def get_all():
     return jsonify(meetups), 200
 
 
+@meetup_v2.route("/meetups/<int:meetupid>")
+@isAuthorized("")
+def get_meetup(meetupid):
+    '''Return a single meetup'''
+    exists = meetup_obj.exists('id', meetupid)
+
+    if exists:
+        meetup_ = meetup_obj.fetch_meetup(meetupid)[0]
+        print(meetup_)
+        meetup = {
+            "status": 200,
+            "data": meetup_
+        }
+        return jsonify(meetup), 200
+
+    notfound_error = {
+        "status": 404,
+        "error": "Not Found"
+    }
+    return jsonify(notfound_error), 404
+
+
 @meetup_v2.route('/meetups', methods=['POST'])
 @validate_input('meetup')
 @isAuthorized("admin")

--- a/app/db.sql
+++ b/app/db.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS roles(
         id serial NOT NULL,
-        role VARCHAR(20) NOT NULL,
+        userrole VARCHAR(20) NOT NULL,
         CONSTRAINT roles_pk PRIMARY KEY (id, role),
         UNIQUE (role)
     );
@@ -92,5 +92,5 @@ CREATE TABLE IF NOT EXISTS rsvp(
     UNIQUE (userid, meetupid)
     );
 
-INSERT INTO roles(role) VALUES('admin') ON CONFLICT DO NOTHING;
-INSERT INTO roles(role) VALUES('user') ON CONFLICT DO NOTHING;
+INSERT INTO roles(userrole) VALUES('admin') ON CONFLICT DO NOTHING;
+INSERT INTO roles(userrole) VALUES('user') ON CONFLICT DO NOTHING;

--- a/app/db.sql
+++ b/app/db.sql
@@ -1,8 +1,8 @@
 CREATE TABLE IF NOT EXISTS roles(
         id serial NOT NULL,
         userrole VARCHAR(20) NOT NULL,
-        CONSTRAINT roles_pk PRIMARY KEY (id, role),
-        UNIQUE (role)
+        CONSTRAINT roles_pk PRIMARY KEY (id, userrole),
+        UNIQUE (userrole)
     );
 
 CREATE TABLE IF NOT EXISTS usertbl (
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS usertbl (
         userrole VARCHAR(20) NOT NULL,
         createOn TIMESTAMP NOT NULL,
         UNIQUE (email, username),
-        CONSTRAINT role_fk FOREIGN KEY (userrole) REFERENCES roles(role)
+        CONSTRAINT role_fk FOREIGN KEY (userrole) REFERENCES roles(userrole)
     );
 
 
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS meetup(
         userid INTEGER,
         createdOn TIMESTAMP NOT NULL,
         topic VARCHAR(80) NOT NULL,
-        location VARCHAR(55) NOT NULL,
+        venue VARCHAR(55) NOT NULL,
         images TEXT[],
         tags TEXT[],
         happeningOn TIMESTAMP NOT NULL,


### PR DESCRIPTION
## What does this PR do?
This allows a user to fetch a specific meetup alongside the questions asked about the same meetup

### Description of the Task to be completed
This will allow a user to view a specific meetup along side a list of questions asked of the same meetup.
The endpoint to be used is `meetups/<id>` using the `GET` request

### Any background Tasks
Editing Tables
Tests for this Feature

### Testing 
- `$ git clone https://github.com/j0nimost/Questioner.git`
- `$ cd Questioner/app/test/v2/`
- `$ pytest test_meetup.py`

### Screenshot
![screenshot from 2019-02-14 17-05-49](https://user-images.githubusercontent.com/24381727/52792431-72b42f80-307c-11e9-92ea-91ab3016121d.png)


