### PR TITLE
#163190201 Ft user able delete comment 

### DIFF
--- a/app/api/v2/views/commentview.py
+++ b/app/api/v2/views/commentview.py
@@ -59,3 +59,32 @@ def patch(commentid):
         "error": "Not Found"
     }
     return jsonify(error), 404
+
+
+@commentv2.route('comments/<int:commentid>', methods=['DELETE'])
+@isAuthorized("")
+def delete(commentid):
+    '''Delete a comment'''
+    exists = comment_obj.exists('id', commentid)
+
+    if exists:
+        token = request.headers.get('Authorization').split(" ")[1]
+        userid, _ = decode_jwt(token)
+
+        comment = comment_obj.fetch('id', commentid)
+
+        if comment['userid'] == userid:
+            _ = comment_obj.delete(commentid)
+            return jsonify(), 204
+        else:
+            notallowed = {
+                "status": 405,
+                "error": "Only comment user can delete"
+            }
+            return jsonify(notallowed), 405
+
+    notfound = {
+        "status": 404,
+        "error": "Not Found"
+    }
+    return jsonify(notfound), 404

--- a/app/test/v2/test_comment.py
+++ b/app/test/v2/test_comment.py
@@ -186,6 +186,50 @@ class CommentTestCase(unittest.TestCase):
         self.assertEqual('Not Found',
                          update_data['error'])
 
+    def test_delete_comment(self):
+        '''Test delete comment'''
+        meetup_resp = self.client.post('api/v2/meetups',
+                                       data=json.dumps(self.meetup),
+                                       headers=self.auth_header)
+        self.assertEqual(meetup_resp.status_code, 201)
+        meetup_data = json.loads(meetup_resp.data)
+        meetupid = meetup_data['data'][0]['id']
+        self.assertIsInstance(meetupid, int)
+        ques_resp = self.client.post(
+            '''api/v2/meetups/{}/questions'''.format(meetupid),
+            data=json.dumps(self.question),
+            headers=self.auth_header
+            )
+        self.assertEqual(ques_resp.status_code, 201)
+        ques_data = json.loads(ques_resp.data)
+        quesid = ques_data['data'][0]['id']
+        self.assertIsInstance(quesid, int)
+
+        comment_res = self.client.post(
+            '''api/v2/questions/{}/comments'''.format(quesid),
+            data=json.dumps(self.comment),
+            headers=self.auth_header
+            )
+        self.assertEqual(comment_res.status_code, 201)
+        comment = json.loads(comment_res.data)
+        commentid = comment['data'][0]['id']
+
+        response = self.client.delete(
+            'api/v2/comments/{}'.format(commentid),
+            headers=self.auth_header
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_comment_notfound(self):
+        '''Test not found comment'''
+        response = self.client.delete(
+            'api/v2/comments/0',
+            headers=self.auth_header
+        )
+        self.assertEqual(response.status_code, 404)
+        error = json.loads(response.data)
+        self.assertEqual('Not Found', error['error'])
+
     def tearDown(self):
         with self.app.app_context():
             drop_tables()


### PR DESCRIPTION
## What does this PR do?
This allows a user to delete their own comment.

### Description of the Task to be completed?
The user should be able to delete their own comment using the `DELETE` request on `comments/<id>` endpoint.

### Any background Tasks
Tests for this Feature

### Testing
- `$ git fetch origin`
- `$ git checkout --track origin/ft-user-able-delete-comment-163190201`
- `$ cd Questioner/app/test/v2`
- `$ pytest test_comment.py`

### Screenshot
![screenshot from 2019-02-16 15-51-41](https://user-images.githubusercontent.com/24381727/52900099-fef05f00-3202-11e9-97f4-33caab317edc.png)
