### PR TITLE
#164118064 Ft user delete question 

### DIFF
--- a/app/api/v2/views/questionview.py
+++ b/app/api/v2/views/questionview.py
@@ -138,3 +138,34 @@ def question_downvote(ques_id):
             "error": "Not Found"
         }
         return jsonify(notfound_json), 404
+
+
+@ques_v2.route('questions/<int:quesid>', methods=['DELETE'])
+@isAuthorized("")
+def delete(quesid):
+    '''Delete a question'''
+    exists = ques_obj.exists('id', quesid)
+
+    if exists:
+        token = request.headers.get('Authorization').split(" ")[1]
+        userid, _ = decode_jwt(token)
+
+        ques = ques_obj.fetch('id', quesid)
+
+        if ques['userid'] == userid:
+            _ = ques_obj.delete(quesid)
+            return jsonify(), 204
+
+        notallowed = {
+            "status": 405,
+            "error": "only question creater can delete"
+        }
+        return jsonify(notallowed), 405
+
+    else:
+        notfound = {
+            "status": 404,
+            "error": "Not Found"
+        }
+
+        return jsonify(notfound), 404

--- a/app/test/v2/test_question.py
+++ b/app/test/v2/test_question.py
@@ -198,6 +198,34 @@ class QuestionTestCase(unittest.TestCase):
             data['error'],
             'unexpected 2 is greater than or equal to the maximum of 2')
 
+    def test_delete_question(self):
+        '''Test the deletion of a question'''
+        meetup_res = self.client.post("api/v2/meetups",
+                                      data=json.dumps(self.meetup),
+                                      headers=self.auth_header)
+        data = json.loads(meetup_res.data)
+        id_ = data['data'][0]['id']
+        response = self.client.post('api/v2/meetups/{}/questions'.format(id_),
+                                    data=json.dumps(self.ques),
+                                    headers=self.auth_header)
+        self.assertEqual(response.status_code, 201)
+        ques_ = json.loads(response.data)
+        ques_id = ques_['data'][0]['id']
+
+        delete_res = self.client.delete('api/v2/questions/{}'.format(ques_id),
+                                        headers=self.auth_header)
+
+        self.assertEqual(delete_res.status_code, 204)
+
+    def test_delete_question_notfound(self):
+        '''Test deletion not found'''
+        response = self.client.delete('api/v2/questions/0',
+                                      headers=self.auth_header)
+
+        self.assertEqual(response.status_code, 404)
+        error = json.loads(response.data)
+        self.assertEqual(error['error'], 'Not Found')
+
     def tearDown(self):
         with self.app.app_context():
             drop_tables()


### PR DESCRIPTION
## What does this PR do?
This allows a user to delete their own questions.

### Description of the Task to be completed
This allows a user to delete a question they asked on the platform. The user can delete a question on the `questions/<int>` endpoint using the `DELETE` request.

### Any background Tasks
Tests for this Feature

### Testing
- `$ git fetch origin`
- `$ git checkout --track origin/ft-user-able-delete-comment-163190201`
- `$ cd Questioner/app/test/v2`
- `$ pytest test_question.py`

### Screenshot
None
